### PR TITLE
find7op: overwrite find7a camera hal

### DIFF
--- a/find7op/BoardConfigVendor.mk
+++ b/find7op/BoardConfigVendor.mk
@@ -1,0 +1,1 @@
+USE_CAMERA_STUB := false

--- a/find7op/find7op-vendor-blobs.mk
+++ b/find7op/find7op-vendor-blobs.mk
@@ -1,0 +1,23 @@
+# Copyright (C) 2013 The OmniROM Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOCAL_PATH := vendor/oppo/find7op
+
+# Call other blobs from find7a
+$(call inherit-product-if-exists, vendor/oppo/find7a/find7a-vendor.mk)
+
+# Libraries
+PRODUCT_COPY_FILES += \
+	$(LOCAL_PATH)/proprietary/lib/hw/camera.msm8974.so:system/lib/hw/camera.vendor.msm8974.so
+

--- a/find7op/find7op-vendor.mk
+++ b/find7op/find7op-vendor.mk
@@ -1,0 +1,19 @@
+# Copyright (C) 2013 The OmniROM Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEVICE_PACKAGE_OVERLAYS := vendor/oppo/find7a/overlay
+
+PRODUCT_PACKAGES += libtime_genoff
+
+$(call inherit-product, vendor/oppo/find7op/find7op-vendor-blobs.mk)


### PR DESCRIPTION
This is necessary to fix recorded videos (on  PC it's upside down)
